### PR TITLE
Import antd modules from its es sub-directory, not from the lib

### DIFF
--- a/src/HOC/translatableFactory.story.tsx
+++ b/src/HOC/translatableFactory.story.tsx
@@ -5,8 +5,8 @@ import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { FormattedMessage, addLocaleData } from 'react-intl';
 import cs from 'react-intl/locale-data/cs';
-import cs_CZ from 'antd/lib/locale-provider/cs_CZ';
-import en_US from 'antd/lib/locale-provider/en_US';
+import cs_CZ from 'antd/es/locale-provider/cs_CZ';
+import en_US from 'antd/es/locale-provider/en_US';
 
 import { Pagination } from 'antd';
 

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 import getDisplayName from 'react-display-name';
-import LocaleProvider, { Locale as AntdLocaleData } from 'antd/lib/locale-provider';
+import LocaleProvider, { Locale as AntdLocaleData } from 'antd/es/locale-provider';
 
 import { LocaleData, LocaleState, State } from '../types';
 


### PR DESCRIPTION
We have to decide which modules are we going to use, otherwise we will end up with including both `antd/lib` and `antd/es` directories in the final bundle. 
I'd suggest using modules from the `es` directory that is much more tree-shaking friendly.