### PR TITLE
Add simple mock of indexedDB to enable running jerome on server

### DIFF
--- a/src/services/sagas/storageHandlers/IndexedDBWrapper.ts
+++ b/src/services/sagas/storageHandlers/IndexedDBWrapper.ts
@@ -1,8 +1,11 @@
-import { openDB } from 'idb';
+import { openDB as openDBReal } from 'idb';
+import openDBMock from './indexedDbMock';
 
 const DATABASE_NAME = '@ackee/jerome';
 const DATABASE_VERSION = 1;
 const DATABASE_STORE_NAME = 'keyvaluepairs';
+
+const openDB = typeof window !== 'undefined' && window.indexedDB ? openDBReal : openDBMock;
 
 const db = openDB(DATABASE_NAME, DATABASE_VERSION, {
     upgrade(nextDb: any) {

--- a/src/services/sagas/storageHandlers/indexedDbMock.ts
+++ b/src/services/sagas/storageHandlers/indexedDbMock.ts
@@ -1,0 +1,25 @@
+export class IndexedDbMock {
+    private name: string;
+    private version: number;
+    private options: object | undefined;
+    private db: {[key: string]: any};
+
+    constructor(name: string, version: number, options?: object) {
+        this.name = name;
+        this.version = version;
+        this.options = options;
+        this.db = {};
+    }
+
+    get(key: string): any {
+        return this.db[key];
+    }
+
+    put(val: any, key: string) {
+        this.db[key] = val;
+    }
+}
+
+export default (dbName: string, dbVersion: number, options?: object): IndexedDbMock => {
+    return new IndexedDbMock(dbName, dbVersion, options);
+};

--- a/src/services/sagas/storageHandlers/indexedDbMock.ts
+++ b/src/services/sagas/storageHandlers/indexedDbMock.ts
@@ -1,13 +1,7 @@
 export class IndexedDbMock {
-    private name: string;
-    private version: number;
-    private options: object | undefined;
     private db: {[key: string]: any};
 
-    constructor(name: string, version: number, options?: object) {
-        this.name = name;
-        this.version = version;
-        this.options = options;
+    constructor() {
         this.db = {};
     }
 
@@ -20,6 +14,6 @@ export class IndexedDbMock {
     }
 }
 
-export default (dbName: string, dbVersion: number, options?: object): IndexedDbMock => {
-    return new IndexedDbMock(dbName, dbVersion, options);
+export default (): IndexedDbMock => {
+    return new IndexedDbMock();
 };


### PR DESCRIPTION
Currently using Jerome in SSR app fails with `indexedDB is not defined in /node_modules/idb/build/cjs/index.js:15:21)` error.
This PR checks `indexedDB availability and possibly use a simple mock that mimics its funcionality.