### PR TITLE
Task/react intl 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,14 @@ if (!Intl.RelativeTimeFormat) {
 
 ### HOC
 
-#### `translatable(intlLocaleData, antdLocaleData): (ContentComponent) => TranslatableContentComponent`
+![Important](./assets/alert-icon.png "Important note")
+To make HOCs works properly, you must have `react-intl` installed just once! So be sure your dependencies structure is flat.
 
-It's actually a translatable HOC factory function. It provides `reac-intl` and `antd` localization context, so you first have to provide localization messages and `antd` locale data.
+#### `translatableFactory(intlLocaleData): (ContentComponent) => TranslatableContentComponent`
 
-> ![Important](./assets/alert-icon.png "Important note")
-To make HOC works properly, you must have `react-intl` installed just once! So be sure your dependencies structure is flat.
+It provides `reac-intl` localization context, so you first have to provide localization messages to the factory that will return the actual HOC.
 
-_Arguments:_
-* `intlLocaleData`: object with messages keyed by locale name, eg.
+`intlLocaleData` - object with messages keyed by locale name, eg.
 
 
 ```js
@@ -89,31 +88,14 @@ const messages = {
 }
 ```
 
-* `intlLocaleData`: object with antd locales keyed by locale name. eg.
-
-```js
-import cs_CZ from 'antd/lib/locale-provider/cs_CZ';
-import en_US from 'antd/lib/locale-provider/en_US';
-
-const messages = {
-    cs: cs_CZ,
-    en: en_US,
-}
-```
-
-_Returns:_
-Function that receives `ContentComponent` and return it wrapped with [IntlProvider](https://github.com/yahoo/react-intl/wiki/Components#intlprovider) and set locale to that given from
+The factory returns function that receives `ContentComponent` and return it wrapped with [IntlProvider](https://github.com/yahoo/react-intl/wiki/Components#intlprovider) which receives locale from the
 `store.translate.locale` store path.
 
 _Example_
 
 ```jsx
 import { FormattedMessage, addLocaleData } from 'react-intl';
-
-import cs_CZ from 'antd/lib/locale-provider/cs_CZ';
-import en_US from 'antd/lib/locale-provider/en_US';
-
-import { translatableHOC } from '@ackee/jerome';
+import { translatableFactory } from '@ackee/jerome';
 
 const ContentComponent = () => (
     <div id="app">
@@ -129,6 +111,63 @@ const messages = {
         'bye.instant': 'Nashledanou',
         'bye.forever': 'Sbohem',
     },
+    en: {
+        hello: 'Hello',
+        'bye.instant': 'See you later',
+        'bye.forever': 'Goodbye',
+    },
+};
+
+const store = createStore((state = initialState) => ({
+    translate: { locale: 'cs' },
+}));
+
+TranslatableComponent = translatableFactory(messages)(ContentComponent);
+
+ReactDOM.render(<TranslatableComponent store={store} />, document.getElementById('app'));
+```
+
+#### `translatableWithAntdFactory(intlLocaleData, antdLocaleData): (ContentComponent) => TranslatableContentComponent`
+
+If you use [Ant design](https://ant.design/docs/react/introduce) components library, you can use this HOC, which extends the [`translatableFactory`](#translatablefactoryintllocaledata-contentcomponent--translatablecontentcomponent) to add `antd` localization context. Only difference (except the name) is that you have to provide `antLocaleData` as a second argument to the factory.
+
+`intlLocaleData` - object with antd locales keyed by locale name. eg.
+
+```js
+import cs_CZ from 'antd/lib/locale-provider/cs_CZ';
+import en_US from 'antd/lib/locale-provider/en_US';
+
+const messages = {
+    cs: cs_CZ,
+    en: en_US,
+}
+```
+
+Returns the same HOC as a [`translatableFactory`](#translatablefactoryintllocaledata-contentcomponent--translatablecontentcomponent), look at the usage example below.
+
+```jsx
+import { FormattedMessage, addLocaleData } from 'react-intl';
+
+import { Pagination } from 'antd';
+import cs_CZ from 'antd/lib/locale-provider/cs_CZ';
+import en_US from 'antd/lib/locale-provider/en_US';
+
+import { translatableWithAntdFactory } from '@ackee/jerome';
+
+const ContentComponent = () => (
+    <div id="app">
+        <h1><FormattedMessage id="hello" /></h1>
+        <Pagination defaultCurrent={1} total={50} showSizeChanger />
+    </div>
+);
+
+const messages = {
+    cs: {
+        hello: 'Cau',
+    },
+    en: {
+        hello: 'Hello',
+    },
 };
 
 const antdMessages = {
@@ -140,7 +179,7 @@ const store = createStore((state = initialState) => ({
     translate: { locale: 'cs' },
 }));
 
-TranslatableComponent = translatableHOC(messages, antdMessages)(ContentComponent);
+TranslatableComponent = translatableWithAntdFactory(messages, antdMessages)(ContentComponent);
 
 ReactDOM.render(<TranslatableComponent store={store} />, document.getElementById('app'));
 ```

--- a/README.md
+++ b/README.md
@@ -24,21 +24,42 @@
 
 ## Installation
 
-Using npm:
-
-```
-npm i -s @ackee/jerome
-```
-
 Using yarn:
 
-```
+```bash
 yarn add @ackee/jerome
+```
+
+Using npm:
+
+```bash
+npm i -s @ackee/jerome
 ```
 
 ## Usage
 
 All parts are independent, but best works all together. Don't forget that for correct usage of selectors your reducer have to be stored with `translate` key (as in example).
+
+### Used APIs
+
+Jerome uses `react-intl@3` which [relies on some native browser APIs](https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md#migrate-to-using-native-intl-apis) so if you're going to use components for plurals or relative time format, be sure that your minimal supported browsers implement those APIs or use polyfills as described bellow
+
+For polyfilling plurals, use [`intl-pluralrules`](https://www.npmjs.com/package/intl-pluralrules) package.
+
+```js
+if (!Intl.PluralRules) {
+  require('intl-pluralrules');
+}
+```
+
+For polyfilling plurals, use [`intl-relativetimeformat`](https://www.npmjs.com/package/@formatjs/intl-relativetimeformat) package.
+
+```js
+if (!Intl.RelativeTimeFormat) {
+  require('@formatjs/intl-relativetimeformat/polyfill');
+  require('@formatjs/intl-relativetimeformat/dist/locale-data/de'); // Add locale data for de
+}
+```
 
 ## API
 
@@ -49,7 +70,7 @@ All parts are independent, but best works all together. Don't forget that for co
 It's actually a translatable HOC factory function. It provides `reac-intl` and `antd` localization context, so you first have to provide localization messages and `antd` locale data.
 
 > ![Important](./assets/alert-icon.png "Important note")
-To make HOC works properly, you must have `react-intl` installed just once!
+To make HOC works properly, you must have `react-intl` installed just once! So be sure your dependencies structure is flat.
 
 _Arguments:_
 * `intlLocaleData`: object with messages keyed by locale name, eg.
@@ -84,21 +105,15 @@ _Returns:_
 Function that receives `ContentComponent` and return it wrapped with [IntlProvider](https://github.com/yahoo/react-intl/wiki/Components#intlprovider) and set locale to that given from
 `store.translate.locale` store path.
 
-> To make everything work properly you also need to set locale data using `addLocaleData` function from
-`react-intl` package. See the snippet below for example of how to do it.
-
 _Example_
 
 ```jsx
 import { FormattedMessage, addLocaleData } from 'react-intl';
-import cs from 'react-intl/locale-data/cs';
 
 import cs_CZ from 'antd/lib/locale-provider/cs_CZ';
 import en_US from 'antd/lib/locale-provider/en_US';
 
 import { translatableHOC } from '@ackee/jerome';
-
-addLocaleData([...cs]);
 
 const ContentComponent = () => (
     <div id="app">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1823,7 +1823,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-2.8.1.tgz",
             "integrity": "sha512-wIEMETv5W90Y3O5VmwDl4BAjgCCmLA6DE0nrQA2z081Xfl9OW6XXmqTgdcfnBy+u2zVC/MDT9/3WfUxr6mpRsQ==",
-            "dev": true,
             "requires": {
                 "@formatjs/intl-utils": "^0.6.1"
             }
@@ -1832,7 +1831,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-0.6.1.tgz",
             "integrity": "sha512-CthSQc/GV94y0cdMpTM69cwH98T/qx9twaZZXh9VZ6B0nL+2KptE5fXqcde4ffrHMZx1bPZJTIpwky4X1Is00A==",
-            "dev": true,
             "requires": {
                 "date-fns": "^2.0.0"
             }
@@ -6065,8 +6063,7 @@
         "date-fns": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0.tgz",
-            "integrity": "sha512-nGZDA64Ktq5uTWV4LEH3qX+foV4AguT5qxwRlJDzJtf57d4xLNwtwrfb7SzKCoikoae8Bvxf0zdaEG/xWssp/w==",
-            "dev": true
+            "integrity": "sha512-nGZDA64Ktq5uTWV4LEH3qX+foV4AguT5qxwRlJDzJtf57d4xLNwtwrfb7SzKCoikoae8Bvxf0zdaEG/xWssp/w=="
         },
         "date-now": {
             "version": "0.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,24 +1183,6 @@
                 "regexpu-core": "^4.5.4"
             }
         },
-        "@babel/polyfill": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-            "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-            "dev": true,
-            "requires": {
-                "core-js": "^2.6.5",
-                "regenerator-runtime": "^0.13.2"
-            },
-            "dependencies": {
-                "regenerator-runtime": {
-                    "version": "0.13.2",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-                    "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-                    "dev": true
-                }
-            }
-        },
         "@babel/preset-env": {
             "version": "7.4.5",
             "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
@@ -1837,6 +1819,24 @@
                 "tslib": "^1.8.1"
             }
         },
+        "@formatjs/intl-relativetimeformat": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-2.8.1.tgz",
+            "integrity": "sha512-wIEMETv5W90Y3O5VmwDl4BAjgCCmLA6DE0nrQA2z081Xfl9OW6XXmqTgdcfnBy+u2zVC/MDT9/3WfUxr6mpRsQ==",
+            "dev": true,
+            "requires": {
+                "@formatjs/intl-utils": "^0.6.1"
+            }
+        },
+        "@formatjs/intl-utils": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-0.6.1.tgz",
+            "integrity": "sha512-CthSQc/GV94y0cdMpTM69cwH98T/qx9twaZZXh9VZ6B0nL+2KptE5fXqcde4ffrHMZx1bPZJTIpwky4X1Is00A==",
+            "dev": true,
+            "requires": {
+                "date-fns": "^2.0.0"
+            }
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -2226,7 +2226,7 @@
         },
         "@storybook/podda": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
+            "resolved": "http://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
             "integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
             "dev": true,
             "requires": {
@@ -2485,6 +2485,12 @@
                     }
                 }
             }
+        },
+        "@types/invariant": {
+            "version": "2.2.30",
+            "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.30.tgz",
+            "integrity": "sha512-98fB+yo7imSD2F7PF7GIpELNgtLNgo5wjivu0W5V4jx+KVVJxo6p/qN4zdzSTBWy4/sN3pPyXwnhRSD28QX+ag==",
+            "dev": true
         },
         "@types/node": {
             "version": "11.13.7",
@@ -3171,7 +3177,7 @@
         },
         "array-equal": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
@@ -3317,7 +3323,7 @@
                 },
                 "util": {
                     "version": "0.10.3",
-                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
                     "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
                     "dev": true,
                     "requires": {
@@ -3398,35 +3404,6 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "auto-changelog": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-1.13.0.tgz",
-            "integrity": "sha512-djreNOUH6i09Lkm/A3oDApJjSrphUb8dxnyCan8CVEN1uHrD02NlraZic9VdPu37ZYcf1lqYNLjuwT5CFZxtPw==",
-            "dev": true,
-            "requires": {
-                "@babel/polyfill": "^7.4.3",
-                "commander": "^2.20.0",
-                "handlebars": "^4.0.12",
-                "lodash.uniqby": "^4.7.0",
-                "node-fetch": "^2.3.0",
-                "parse-github-url": "^1.0.2",
-                "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "6.1.2",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz",
-                    "integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ==",
-                    "dev": true
-                }
-            }
-        },
         "autoprefixer": {
             "version": "9.5.1",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
@@ -3481,7 +3458,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -3565,7 +3542,7 @@
             "dependencies": {
                 "jsesc": {
                     "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
                     "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
                     "dev": true
                 }
@@ -3585,7 +3562,7 @@
         },
         "babel-helper-is-nodes-equiv": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
             "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
             "dev": true
         },
@@ -3671,7 +3648,7 @@
         },
         "babel-plugin-istanbul": {
             "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+            "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
             "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
             "dev": true,
             "requires": {
@@ -3854,7 +3831,7 @@
         },
         "babel-plugin-syntax-object-rest-spread": {
             "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
             "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
             "dev": true
         },
@@ -4724,7 +4701,7 @@
         },
         "browserify-aes": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
@@ -4761,7 +4738,7 @@
         },
         "browserify-rsa": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
@@ -4815,7 +4792,7 @@
         },
         "buffer": {
             "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
@@ -4942,7 +4919,7 @@
         },
         "callsites": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
             "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
             "dev": true
         },
@@ -5013,15 +4990,12 @@
             }
         },
         "changelog-it": {
-            "version": "github:AckeeCZ/changelog-it#e97e57666e1ed5b6b5fb782390c57950fd963ab3",
+            "version": "github:AckeeCZ/changelog-it#4686140d043f911dd2ac959c82072e4b50faa7e2",
             "from": "github:AckeeCZ/changelog-it",
             "dev": true,
             "requires": {
-                "auto-changelog": "^1.11.0",
-                "commander": "^2.19.0",
                 "keep-a-changelog": "^0.7.0",
-                "lodash": "^4.17.11",
-                "prompt": "^1.0.0"
+                "lodash": "^4.17.11"
             }
         },
         "character-entities": {
@@ -5340,7 +5314,7 @@
         },
         "clone-deep": {
             "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+            "resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
             "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
             "dev": true,
             "requires": {
@@ -5414,7 +5388,8 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
             "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "combined-stream": {
             "version": "1.0.7",
@@ -5652,12 +5627,6 @@
                 "toggle-selection": "^1.0.6"
             }
         },
-        "core-js": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-            "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-            "dev": true
-        },
         "core-js-compat": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
@@ -5762,7 +5731,7 @@
         },
         "create-hash": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
@@ -5775,7 +5744,7 @@
         },
         "create-hmac": {
             "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
@@ -5914,7 +5883,7 @@
         },
         "css-select": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
@@ -6045,12 +6014,6 @@
             "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==",
             "dev": true
         },
-        "cycle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-            "dev": true
-        },
         "cyclist": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -6095,6 +6058,12 @@
                     }
                 }
             }
+        },
+        "date-fns": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0.tgz",
+            "integrity": "sha512-nGZDA64Ktq5uTWV4LEH3qX+foV4AguT5qxwRlJDzJtf57d4xLNwtwrfb7SzKCoikoae8Bvxf0zdaEG/xWssp/w==",
+            "dev": true
         },
         "date-now": {
             "version": "0.1.4",
@@ -6274,7 +6243,7 @@
         },
         "diffie-hellman": {
             "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
@@ -6460,7 +6429,7 @@
             "dependencies": {
                 "immutable": {
                     "version": "3.7.6",
-                    "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+                    "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
                     "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
                     "dev": true
                 }
@@ -6468,7 +6437,7 @@
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
@@ -6980,7 +6949,7 @@
             "dependencies": {
                 "doctrine": {
                     "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                    "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
                     "dev": true,
                     "requires": {
@@ -7557,12 +7526,6 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "dev": true
         },
-        "eyes": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-            "dev": true
-        },
         "fast-deep-equal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -7645,7 +7608,7 @@
             "dependencies": {
                 "core-js": {
                     "version": "1.2.7",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                    "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
                     "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
                     "dev": true
                 }
@@ -7699,7 +7662,7 @@
             "dependencies": {
                 "fs-extra": {
                     "version": "0.30.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                    "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
                     "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
                     "dev": true,
                     "requires": {
@@ -7765,7 +7728,7 @@
         },
         "finalhandler": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "dev": true,
             "requires": {
@@ -7955,7 +7918,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -7976,12 +7940,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -7996,17 +7962,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -8123,7 +8092,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -8135,6 +8105,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -8149,6 +8120,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -8156,12 +8128,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -8180,6 +8154,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -8260,7 +8235,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -8272,6 +8248,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -8357,7 +8334,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -8393,6 +8371,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -8412,6 +8391,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -8455,12 +8435,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -8517,7 +8499,7 @@
         },
         "get-stream": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
         },
@@ -8675,7 +8657,7 @@
         },
         "globby": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
             "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
             "dev": true,
             "requires": {
@@ -9101,7 +9083,7 @@
         },
         "http-errors": {
             "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "dev": true,
             "requires": {
@@ -9132,12 +9114,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-            "dev": true
-        },
-        "i": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-            "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
             "dev": true
         },
         "iconv-lite": {
@@ -9447,34 +9423,32 @@
             "dev": true
         },
         "intl-format-cache": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
-            "integrity": "sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY=",
+            "version": "4.1.14",
+            "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.1.14.tgz",
+            "integrity": "sha512-wXDqD40ESpc9YiSy3yIt+ABQnFm+i+8y2S9fEa8hQmakrDKY068ECiwIcm8Y/hTU1/iSboqeW4+7RB4L9JrrwQ==",
+            "dev": true
+        },
+        "intl-locales-supported": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/intl-locales-supported/-/intl-locales-supported-1.4.5.tgz",
+            "integrity": "sha512-D7oriM5x46rd7kNlSW0f9noIBegFr3ReIM6xlMpwH4lfIPD/zvBelPlCjR10IK16boGJG9lKccOvRAM8wzpbrA==",
             "dev": true
         },
         "intl-messageformat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
-            "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
+            "version": "6.1.10",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-6.1.10.tgz",
+            "integrity": "sha512-h5lIjqbmQZIQE9c2ay7dTGeU13ME5pX1MwNFyXVTrzR7DPQYderQMSrnWN25OYVCeplgxNmmFu7nDlmx3bDbkg==",
             "dev": true,
             "requires": {
-                "intl-messageformat-parser": "1.4.0"
+                "intl-format-cache": "^4.1.14",
+                "intl-messageformat-parser": "^3.0.7"
             }
         },
         "intl-messageformat-parser": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
-            "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.0.7.tgz",
+            "integrity": "sha512-L16VbbV3NFaiZV65XwOIH9fBe52TS2EkOR0k8Y4ratsgTE7KPEbcUCUrz/iEQwJo7BcWY4ohkZbeYZRgAiPR1Q==",
             "dev": true
-        },
-        "intl-relativeformat": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
-            "integrity": "sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=",
-            "dev": true,
-            "requires": {
-                "intl-messageformat": "^2.0.0"
-            }
         },
         "invariant": {
             "version": "2.2.4",
@@ -10382,7 +10356,7 @@
         },
         "jest-get-type": {
             "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+            "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
             "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
             "dev": true
         },
@@ -11088,7 +11062,7 @@
         },
         "jsonfile": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "dev": true,
             "requires": {
@@ -11441,12 +11415,6 @@
             "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
             "dev": true
         },
-        "lodash.uniqby": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-            "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
-            "dev": true
-        },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -11588,7 +11556,7 @@
         },
         "marked": {
             "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+            "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
             "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
             "dev": true
         },
@@ -11628,7 +11596,7 @@
         },
         "media-typer": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
         },
@@ -11827,7 +11795,7 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
@@ -11890,7 +11858,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -11971,12 +11939,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
-        },
-        "ncp": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
-            "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
             "dev": true
         },
         "nearley": {
@@ -12405,7 +12367,7 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -12496,7 +12458,7 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
@@ -12513,7 +12475,7 @@
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -12768,12 +12730,6 @@
                 "is-hexadecimal": "^1.0.0"
             }
         },
-        "parse-github-url": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-            "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-            "dev": true
-        },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -12863,7 +12819,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -13010,12 +12966,6 @@
                     "dev": true
                 }
             }
-        },
-        "pkginfo": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-            "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-            "dev": true
         },
         "pluralize": {
             "version": "7.0.0",
@@ -13289,7 +13239,7 @@
         },
         "pretty-hrtime": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+            "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
             "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
             "dev": true
         },
@@ -13367,20 +13317,6 @@
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.9.0",
                 "function-bind": "^1.1.1"
-            }
-        },
-        "prompt": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
-            "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
-            "dev": true,
-            "requires": {
-                "colors": "^1.1.2",
-                "pkginfo": "0.x.x",
-                "read": "1.0.x",
-                "revalidator": "0.1.x",
-                "utile": "0.3.x",
-                "winston": "2.1.x"
             }
         },
         "prompts": {
@@ -13552,7 +13488,7 @@
         },
         "ramda": {
             "version": "0.21.0",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
+            "resolved": "http://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
             "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
             "dev": true
         },
@@ -13635,7 +13571,7 @@
         },
         "raw-loader": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+            "resolved": "http://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
             "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
             "dev": true
         },
@@ -14556,23 +14492,31 @@
             }
         },
         "react-intl": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.8.0.tgz",
-            "integrity": "sha512-1cSasNkHxZOXYYhms9Q1tSEWF8AWZQNq3nPLB/j8mYV0ZTSt2DhGQXHfKrKQMu4cgj9J1Crqg7xFPICTBgzqtQ==",
+            "version": "3.1.11",
+            "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-3.1.11.tgz",
+            "integrity": "sha512-hnsdhje7IrvyCyW6sdQD7FcVmdkzm9SdFrb+cnwnj5J4QHjZ8X7oVqGPB05sK482Ja1FLUgw1fHheaWRqPAKRA==",
             "dev": true,
             "requires": {
-                "hoist-non-react-statics": "^2.5.5",
-                "intl-format-cache": "^2.0.5",
-                "intl-messageformat": "^2.1.0",
-                "intl-relativeformat": "^2.1.0",
-                "invariant": "^2.1.1"
+                "@formatjs/intl-relativetimeformat": "^2.8.0",
+                "@types/hoist-non-react-statics": "^3.3.1",
+                "@types/invariant": "^2.2.30",
+                "hoist-non-react-statics": "^3.3.0",
+                "intl-format-cache": "^4.1.13",
+                "intl-locales-supported": "^1.4.5",
+                "intl-messageformat": "^6.1.6",
+                "intl-messageformat-parser": "^3.0.7",
+                "invariant": "^2.1.1",
+                "shallow-equal": "^1.1.0"
             },
             "dependencies": {
                 "hoist-non-react-statics": {
-                    "version": "2.5.5",
-                    "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-                    "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-                    "dev": true
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+                    "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+                    "dev": true,
+                    "requires": {
+                        "react-is": "^16.7.0"
+                    }
                 }
             }
         },
@@ -14732,15 +14676,6 @@
                 "velocity-react": "^1.4.1"
             }
         },
-        "read": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-            "dev": true,
-            "requires": {
-                "mute-stream": "~0.0.4"
-            }
-        },
         "read-all-stream": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
@@ -14814,7 +14749,7 @@
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
@@ -15229,7 +15164,7 @@
         },
         "require-uncached": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
@@ -15248,7 +15183,7 @@
                 },
                 "callsites": {
                     "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
                     "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
                     "dev": true
                 },
@@ -15336,12 +15271,6 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
-        "revalidator": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-            "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
-            "dev": true
-        },
         "rimraf": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -15422,7 +15351,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
@@ -15454,7 +15383,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -15618,7 +15547,7 @@
         },
         "sha.js": {
             "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
@@ -15640,7 +15569,7 @@
             "dependencies": {
                 "kind-of": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                     "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
                     "dev": true,
                     "requires": {
@@ -16018,12 +15947,6 @@
             "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
             "dev": true
         },
-        "stack-trace": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-            "dev": true
-        },
         "stack-utils": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -16203,7 +16126,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -16221,7 +16144,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
@@ -16268,7 +16191,7 @@
                 },
                 "file-loader": {
                     "version": "1.1.11",
-                    "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+                    "resolved": "http://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
                     "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
                     "dev": true,
                     "requires": {
@@ -16603,7 +16526,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -16845,7 +16768,7 @@
             "dependencies": {
                 "doctrine": {
                     "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+                    "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
                     "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
                     "dev": true,
                     "requires": {
@@ -17457,34 +17380,6 @@
             "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
             "dev": true
         },
-        "utile": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
-            "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
-            "dev": true,
-            "requires": {
-                "async": "~0.9.0",
-                "deep-equal": "~0.2.1",
-                "i": "0.3.x",
-                "mkdirp": "0.x.x",
-                "ncp": "1.0.x",
-                "rimraf": "2.x.x"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "0.9.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                    "dev": true
-                },
-                "deep-equal": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-                    "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
-                    "dev": true
-                }
-            }
-        },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -17647,7 +17542,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -17923,41 +17818,6 @@
                 }
             }
         },
-        "winston": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
-            "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
-            "dev": true,
-            "requires": {
-                "async": "~1.0.0",
-                "colors": "1.0.x",
-                "cycle": "1.0.x",
-                "eyes": "0.1.x",
-                "isstream": "0.1.x",
-                "pkginfo": "0.3.x",
-                "stack-trace": "0.0.x"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-                    "dev": true
-                },
-                "colors": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-                    "dev": true
-                },
-                "pkginfo": {
-                    "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-                    "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-                    "dev": true
-                }
-            }
-        },
         "wordwrap": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -17975,7 +17835,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2530,10 +2530,13 @@
             }
         },
         "@types/react-intl": {
-            "version": "2.3.18",
-            "resolved": "https://registry.npmjs.org/@types/react-intl/-/react-intl-2.3.18.tgz",
-            "integrity": "sha512-DVNJs49zUxKRZng8VuILE886Yihdsf3yLr5vHk9zJrmF8SyRSK3sxNSvikAKxNkv9hX55XBTJShz6CkJnbNjgg==",
-            "dev": true
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/react-intl/-/react-intl-3.0.0.tgz",
+            "integrity": "sha512-k8F3d05XQGEqSWIfK97bBjZe4z9RruXU9Wa7OZ2iUC5pdeIpzuQDZe/9C2J3Xir5//ZtAkhcv08Wfx3n5TBTQg==",
+            "dev": true,
+            "requires": {
+                "react-intl": "*"
+            }
         },
         "@types/react-redux": {
             "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "prop-types": "15.7.x",
         "react": "16.8.x",
         "react-dom": "16.8.x",
-        "react-intl": "2.8.x",
+        "react-intl": "^3.1.11",
         "react-redux": "7.x",
         "redux": "4.x",
         "redux-mock-store": "1.5.x",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "url": "https://github.com/AckeeCZ/jerome"
     },
     "dependencies": {
+        "@formatjs/intl-relativetimeformat": "^2.8.1",
         "idb": "4.0.x",
         "react-display-name": "^0.2.4"
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "antd": "3.19.x",
         "prop-types": "15.7.x",
         "react": "16.8.x",
-        "react-intl": "2.8.x",
+        "react-intl": "^3.1.11",
         "react-redux": "7.0.x",
         "redux-saga": "1.0.x"
     },
@@ -58,7 +58,7 @@
         "@storybook/react": "^4.1.1",
         "@types/react": "^16.8.22",
         "@types/react-dom": "^16.8.4",
-        "@types/react-intl": "^2.3.18",
+        "@types/react-intl": "^3.0.0",
         "@types/react-redux": "^7.1.0",
         "@types/redux": "^3.6.0",
         "@types/storybook__react": "^3.0.9",

--- a/src/HOC/index.ts
+++ b/src/HOC/index.ts
@@ -1,0 +1,2 @@
+export { default as translatableFactory } from './translatableFactory';
+export { default as translatableWithAntdFactory } from './translatableWithAntdFactory';

--- a/src/HOC/translatableFactory.story.tsx
+++ b/src/HOC/translatableFactory.story.tsx
@@ -26,13 +26,13 @@ const messages = {
         foo: 'Ano, ja jsem foo',
         'bar.baz': 'Ne, ja jsem bar baz',
         text: 'Čus, já jsem volitelný text',
-        htmlText: 'Čus já jsem <a href="http://ackee.cz" target="_blank">odkaz</a>'
+        htmlText: 'Čus já jsem <a href="http://ackee.cz" target="_blank">odkaz</a>',
     },
     en: {
         foo: 'Yeah, I am foo',
         'bar.baz': 'No, I am bar baz',
         text: 'Hello, I am custom text',
-        htmlText: 'Hi i\'m <a href="http://ackee.de" target="_blank">link</a>'
+        htmlText: 'Hi i\'m <a href="http://ackee.de" target="_blank">link</a>',
     },
 };
 
@@ -62,10 +62,10 @@ const localeChangeHandler = (e: SyntheticEvent<{ value: string }>) =>
 
 interface Props {
     locale: Locale;
-    text?: React.ReactNode;
+    children?: React.ReactNode;
 }
 
-const ContentComponent: React.SFC<Props> = ({ locale, text }) => (
+const ContentComponent: React.SFC<Props> = ({ locale, children }) => (
     <div>
         {['cs', 'en'].map(lang => (
             <div key={lang}>
@@ -79,37 +79,53 @@ const ContentComponent: React.SFC<Props> = ({ locale, text }) => (
                 />
             </div>
         ))}
-        <Pagination defaultCurrent={1} total={50} showSizeChanger />
-        <h1>
-            <FormattedMessage id="foo" />
-        </h1>
-        <h2>
-            <FormattedMessage id="bar.baz" />
-        </h2>
-        <p>
-            <FormattedHTMLMessage id="htmlText" />
-        </p>
-        <p>
-            <FormattedRelativeTime value={-20} unit="minute"/>
-        </p>
-        <p>{text}</p>
+        {children}
     </div>
 );
 
 ContentComponent.propTypes = {
     locale: PropTypes.string.isRequired,
-    text: PropTypes.node,
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
 };
 
 ContentComponent.defaultProps = {
-    text: null,
+    children: null,
 };
 
-storiesOf('HOC|translatable', module).add('simple', () => {
-    const TranslatableComponent = translatable(messages, antdLocales)(ContentComponent);
-    return (
-        <Provider store={store}>
-            <TranslatableComponent text={<FormattedMessage id="text" />} />
-        </Provider>
-    );
-});
+storiesOf('HOC|translatable', module)
+    .add('simple', () => {
+        const TranslatableComponent = translatable(messages, antdLocales)(ContentComponent);
+        return (
+            <Provider store={store}>
+                <TranslatableComponent>
+                    <Pagination defaultCurrent={1} total={50} showSizeChanger />
+                    <h1>
+                        <FormattedMessage id="foo" />
+                    </h1>
+                    <h2>
+                        <FormattedMessage id="bar.baz" />
+                    </h2>
+                    <p>
+                        <FormattedHTMLMessage id="htmlText" />
+                    </p>
+                    <p>
+                        <FormattedRelativeTime value={-20} unit="minute" />
+                    </p>
+                    <p>
+                        <FormattedMessage id="text" />
+                    </p>
+                </TranslatableComponent>
+            </Provider>
+        );
+    })
+    .add('without antd locales', () => {
+        const TranslatableComponent = translatable(messages)(ContentComponent);
+        return (
+            <Provider store={store}>
+                <TranslatableComponent>
+                    <p>Notice that no matter which language you select, component always use English</p>
+                    <Pagination defaultCurrent={1} total={50} showSizeChanger />
+                </TranslatableComponent>
+            </Provider>
+        );
+    });

--- a/src/HOC/translatableFactory.story.tsx
+++ b/src/HOC/translatableFactory.story.tsx
@@ -3,8 +3,7 @@ import React, { SyntheticEvent } from 'react';
 import PropTypes from 'prop-types';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { FormattedMessage, addLocaleData, FormattedHTMLMessage, FormattedRelative } from 'react-intl';
-import cs from 'react-intl/locale-data/cs';
+import { FormattedMessage, FormattedHTMLMessage, FormattedRelativeTime } from 'react-intl';
 import cs_CZ from 'antd/es/locale-provider/cs_CZ';
 import en_US from 'antd/es/locale-provider/en_US';
 
@@ -17,7 +16,10 @@ import 'antd/es/pagination/style/index.less';
 
 import translatable from './translatableFactory';
 
-addLocaleData([...cs]);
+if (!Intl.RelativeTimeFormat) {
+    require('@formatjs/intl-relativetimeformat/polyfill');
+    require('@formatjs/intl-relativetimeformat/dist/locale-data/cs');
+}
 
 const messages = {
     cs: {
@@ -88,7 +90,7 @@ const ContentComponent: React.SFC<Props> = ({ locale, text }) => (
             <FormattedHTMLMessage id="htmlText" />
         </p>
         <p>
-            <FormattedRelative value={Date.now() - 20 * 60 * 1000} units="minute"/>
+            <FormattedRelativeTime value={-20} unit="minute"/>
         </p>
         <p>{text}</p>
     </div>

--- a/src/HOC/translatableFactory.story.tsx
+++ b/src/HOC/translatableFactory.story.tsx
@@ -15,6 +15,7 @@ import { Locale } from '../types';
 import 'antd/es/pagination/style/index.less';
 
 import translatable from './translatableFactory';
+import translatableWithAntd from './translatableWithAntdFactory';
 
 if (!Intl.RelativeTimeFormat) {
     require('@formatjs/intl-relativetimeformat/polyfill');
@@ -94,11 +95,10 @@ ContentComponent.defaultProps = {
 
 storiesOf('HOC|translatable', module)
     .add('simple', () => {
-        const TranslatableComponent = translatable(messages, antdLocales)(ContentComponent);
+        const TranslatableComponent = translatable(messages)(ContentComponent);
         return (
             <Provider store={store}>
                 <TranslatableComponent>
-                    <Pagination defaultCurrent={1} total={50} showSizeChanger />
                     <h1>
                         <FormattedMessage id="foo" />
                     </h1>
@@ -118,12 +118,14 @@ storiesOf('HOC|translatable', module)
             </Provider>
         );
     })
-    .add('without antd locales', () => {
-        const TranslatableComponent = translatable(messages)(ContentComponent);
+    .add('with Antd', () => {
+        const TranslatableComponent = translatableWithAntd(messages, antdLocales)(ContentComponent);
         return (
             <Provider store={store}>
                 <TranslatableComponent>
-                    <p>Notice that no matter which language you select, component always use English</p>
+                    <p>
+                        <FormattedMessage id="foo" />
+                    </p>
                     <Pagination defaultCurrent={1} total={50} showSizeChanger />
                 </TranslatableComponent>
             </Provider>

--- a/src/HOC/translatableFactory.story.tsx
+++ b/src/HOC/translatableFactory.story.tsx
@@ -3,7 +3,7 @@ import React, { SyntheticEvent } from 'react';
 import PropTypes from 'prop-types';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { FormattedMessage, addLocaleData } from 'react-intl';
+import { FormattedMessage, addLocaleData, FormattedHTMLMessage, FormattedRelative } from 'react-intl';
 import cs from 'react-intl/locale-data/cs';
 import cs_CZ from 'antd/es/locale-provider/cs_CZ';
 import en_US from 'antd/es/locale-provider/en_US';
@@ -24,11 +24,13 @@ const messages = {
         foo: 'Ano, ja jsem foo',
         'bar.baz': 'Ne, ja jsem bar baz',
         text: 'Čus, já jsem volitelný text',
+        htmlText: 'Čus já jsem <a href="http://ackee.cz" target="_blank">odkaz</a>'
     },
     en: {
         foo: 'Yeah, I am foo',
         'bar.baz': 'No, I am bar baz',
         text: 'Hello, I am custom text',
+        htmlText: 'Hi i\'m <a href="http://ackee.de" target="_blank">link</a>'
     },
 };
 
@@ -82,6 +84,12 @@ const ContentComponent: React.SFC<Props> = ({ locale, text }) => (
         <h2>
             <FormattedMessage id="bar.baz" />
         </h2>
+        <p>
+            <FormattedHTMLMessage id="htmlText" />
+        </p>
+        <p>
+            <FormattedRelative value={Date.now() - 20 * 60 * 1000} units="minute"/>
+        </p>
         <p>{text}</p>
     </div>
 );

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -39,7 +39,6 @@ const translatableFactory = (intlLocaleData: LocaleData, antdLocaleData: LocaleD
                 const { locale } = this.props;
                 const intlProviderProps = {
                     locale,
-                    key: locale,
                     messages: intlLocaleData[locale],
                     textComponent: Fragment,
                 };

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -3,18 +3,18 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 import getDisplayName from 'react-display-name';
-import AntdLocaleProvider, { Locale as AntdLocaleData } from 'antd/es/locale-provider';
 
 import { LocaleData, LocaleState, State } from '../types';
 
 import { translateSelector } from '../services/selectors';
 import { createIntlProvider, destroyIntlProvider } from '../services/actions';
 
-interface WrappedProps extends LocaleState {
+export interface WrappedProps extends LocaleState {
     [extraProps: string]: any;
+    locale: string;
 }
 
-const translatableFactory = (intlLocaleData: LocaleData, antdLocaleData?: LocaleData<AntdLocaleData>): any => {
+const translatableFactory = (intlLocaleData: LocaleData): any => {
     return (TranslatableComponent: React.ComponentType<WrappedProps>) => {
         class Translatable extends Component<WrappedProps> {
             static displayName = `Translatable(${getDisplayName(TranslatableComponent)})`;
@@ -41,14 +41,10 @@ const translatableFactory = (intlLocaleData: LocaleData, antdLocaleData?: Locale
                     locale,
                     messages: intlLocaleData[locale],
                 };
-                const LocaleProvider = antdLocaleData ? AntdLocaleProvider : React.Fragment;
-                const localeProviderProps = antdLocaleData ? { locale: antdLocaleData[locale] } : {};
 
                 return (
                     <IntlProvider {...intlProviderProps}>
-                        <LocaleProvider {...localeProviderProps}>
-                            <TranslatableComponent {...this.props} />
-                        </LocaleProvider>
+                        <TranslatableComponent {...this.props} />
                     </IntlProvider>
                 );
             }

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 import getDisplayName from 'react-display-name';
-import LocaleProvider, { Locale as AntdLocaleData } from 'antd/es/locale-provider';
+import AntdLocaleProvider, { Locale as AntdLocaleData } from 'antd/es/locale-provider';
 
 import { LocaleData, LocaleState, State } from '../types';
 
@@ -14,7 +14,7 @@ interface WrappedProps extends LocaleState {
     [extraProps: string]: any;
 }
 
-const translatableFactory = (intlLocaleData: LocaleData, antdLocaleData: LocaleData<AntdLocaleData>): any => {
+const translatableFactory = (intlLocaleData: LocaleData, antdLocaleData?: LocaleData<AntdLocaleData>): any => {
     return (TranslatableComponent: React.ComponentType<WrappedProps>) => {
         class Translatable extends Component<WrappedProps> {
             static displayName = `Translatable(${getDisplayName(TranslatableComponent)})`;
@@ -41,10 +41,12 @@ const translatableFactory = (intlLocaleData: LocaleData, antdLocaleData: LocaleD
                     locale,
                     messages: intlLocaleData[locale],
                 };
+                const LocaleProvider = antdLocaleData ? AntdLocaleProvider : React.Fragment;
+                const localeProviderProps = antdLocaleData ? { locale: antdLocaleData[locale] } : {};
 
                 return (
                     <IntlProvider {...intlProviderProps}>
-                        <LocaleProvider locale={antdLocaleData[locale]}>
+                        <LocaleProvider {...localeProviderProps}>
                             <TranslatableComponent {...this.props} />
                         </LocaleProvider>
                     </IntlProvider>

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -40,7 +40,6 @@ const translatableFactory = (intlLocaleData: LocaleData, antdLocaleData: LocaleD
                 const intlProviderProps = {
                     locale,
                     messages: intlLocaleData[locale],
-                    textComponent: Fragment,
                 };
 
                 return (

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { IntlProvider } from 'react-intl';

--- a/src/HOC/translatableWithAntdFactory.tsx
+++ b/src/HOC/translatableWithAntdFactory.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import LocaleProvider, { Locale as AntdLocaleData } from 'antd/es/locale-provider';
+
+import { LocaleData } from '../types';
+
+import translatableFactory, { WrappedProps } from './translatableFactory';
+
+const translatableWithAntdFactory = (intlLocaleData: LocaleData, antdLocaleData: LocaleData<AntdLocaleData>): any => {
+    const translatable = translatableFactory(intlLocaleData);
+
+    return (TranslatableComponent: React.ComponentType<WrappedProps>) => {
+        const TranslatableWithAntd: React.StatelessComponent<WrappedProps> = props => (
+            <LocaleProvider locale={antdLocaleData[props.locale]}>
+                <TranslatableComponent {...props} />
+            </LocaleProvider>
+        );
+
+        TranslatableWithAntd.propTypes = {
+            locale: PropTypes.string.isRequired,
+        };
+
+        return translatable(TranslatableWithAntd);
+    };
+};
+
+export default translatableWithAntdFactory;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default as translatableHOC } from './HOC/translatableFactory';
+export * from './HOC';
 
 export { default as saga, getIntl } from './services/sagas';
 

--- a/src/services/sagas/intlProvider.ts
+++ b/src/services/sagas/intlProvider.ts
@@ -1,6 +1,6 @@
 import { Action, Store } from '../../types';
 import { select, takeEvery, call, take, race } from 'redux-saga/effects';
-import { IntlProvider } from 'react-intl';
+import { createIntl, createIntlCache } from 'react-intl';
 
 import types from '../actionTypes';
 import { translateSelector } from '../selectors';
@@ -30,7 +30,8 @@ function* createIntlProvider() {
         messages: store.intlData[locale],
     };
 
-    const { intl } = new IntlProvider(intlConfig).getChildContext();
+    const cache = createIntlCache();
+    const intl = createIntl(intlConfig, cache);
 
     store.intl = intl;
 }


### PR DESCRIPTION
Starts to use new `react-intl@3` having support of [new context API](https://github.com/formatjs/react-intl/pull/1186). That means getting rid of unnecessary whole  app rerenders 🎉 

Since it's a major version, there are a breaking changes, you can check them in their [Migration guide](https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md#creating-intl-without-using-provider).

Split `translatableHOC` to `translatableFactory` and `translatableWithAntdFactory` to be able to use the HOC even in apps without Ant design.