### PR TITLE
Feature/use raw intl provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5010,8 +5010,9 @@
             "from": "github:AckeeCZ/changelog-it",
             "dev": true,
             "requires": {
+                "commander": "^2.19.0",
                 "keep-a-changelog": "^0.7.0",
-                "lodash": "^4.17.11"
+                "lodash": "^4.17.15"
             }
         },
         "character-entities": {

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -25,6 +25,23 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
                 destroyIntlProvider: PropTypes.func.isRequired,
             };
 
+            static getDerivedStateFromProps(props: WrappedProps, prevState: WrappedState) {
+                if (!prevState || props.locale !== prevState.locale) {
+                    const intlConfig = {
+                        locale: props.locale,
+                        messages: intlLocaleData[props.locale],
+                    };
+
+                    const cache = createIntlCache();
+                    const intl = createIntl(intlConfig, cache);
+                    return {
+                        intl,
+                        locale: props.locale,
+                    };
+                }
+                return null;
+            }
+
             componentDidMount() {
                 this.props.createIntlProvider({
                     intlData: intlLocaleData,
@@ -43,9 +60,9 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
                 };
 
                 return (
-                    <IntlProvider {...intlProviderProps}>
+                    <RawIntlProvider value={this.state.intl}>
                         <TranslatableComponent {...this.props} />
-                    </IntlProvider>
+                    </RawIntlProvider>
                 );
             }
         }
@@ -56,10 +73,7 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
             destroyIntlProvider,
         };
 
-        return connect(
-            mapStateToProps,
-            mapDispatchToProps,
-        )(Translatable);
+        return connect(mapStateToProps, mapDispatchToProps)(Translatable);
     };
 };
 

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { RawIntlProvider, createIntl, createIntlCache, IntlShape } from 'react-intl';
+import { RawIntlProvider, createIntl, createIntlCache, IntlShape, IntlCache } from 'react-intl';
 import getDisplayName from 'react-display-name';
 
 import { LocaleData, LocaleState, State } from '../types';
@@ -17,11 +17,31 @@ export interface WrappedProps extends LocaleState {
 interface WrappedState {
     locale: string;
     intl: IntlShape;
+    cache: IntlCache;
+}
+
+function shouldRecreateIntl(props: WrappedProps, state: WrappedState): boolean {
+    return !state || props.locale !== state.locale;
 }
 
 const translatableFactory = (intlLocaleData: LocaleData): any => {
+    function prepareConfig(props: WrappedProps) {
+        return {
+            locale: props.locale,
+            messages: intlLocaleData[props.locale],
+        };
+    }
+
     return (TranslatableComponent: React.ComponentClass<WrappedProps>) => {
         class Translatable extends Component<WrappedProps, WrappedState> {
+            private cache: IntlCache = createIntlCache();
+
+            public state: WrappedState = {
+                locale: this.props.locale,
+                intl: createIntl(prepareConfig(this.props), this.cache),
+                cache: this.cache,
+            };
+
             static displayName = `Translatable(${getDisplayName(TranslatableComponent)})`;
 
             static propTypes = {
@@ -31,16 +51,9 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
             };
 
             static getDerivedStateFromProps(props: WrappedProps, prevState: WrappedState) {
-                if (!prevState || props.locale !== prevState.locale) {
-                    const intlConfig = {
-                        locale: props.locale,
-                        messages: intlLocaleData[props.locale],
-                    };
-
-                    const cache = createIntlCache();
-                    const intl = createIntl(intlConfig, cache);
+                if (shouldRecreateIntl(props, prevState)) {
                     return {
-                        intl,
+                        intl: createIntl(prepareConfig(props), prevState.cache),
                         locale: props.locale,
                     };
                 }
@@ -54,7 +67,7 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
             }
 
             componentDidUpdate(_: WrappedProps, prevState: WrappedState) {
-                if (this.state.intl !== prevState.intl) {
+                if (this.state.locale !== prevState.locale) {
                     this.props.destroyIntlProvider();
                     this.props.createIntlProvider({
                         intl: this.state.intl,

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -7,7 +7,7 @@ import getDisplayName from 'react-display-name';
 import { LocaleData, LocaleState, State } from '../types';
 
 import { translateSelector } from '../services/selectors';
-import { createIntlProvider, destroyIntlProvider } from '../services/actions';
+import { setIntl } from '../services/actions';
 
 export interface WrappedProps extends LocaleState {
     [extraProps: string]: any;
@@ -46,8 +46,7 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
 
             static propTypes = {
                 locale: PropTypes.string.isRequired,
-                createIntlProvider: PropTypes.func.isRequired,
-                destroyIntlProvider: PropTypes.func.isRequired,
+                setIntl: PropTypes.func.isRequired,
             };
 
             static getDerivedStateFromProps(props: WrappedProps, prevState: WrappedState) {
@@ -61,22 +60,17 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
             }
 
             componentDidMount() {
-                this.props.createIntlProvider({
+                this.props.setIntl({
                     intl: this.state.intl,
                 });
             }
 
             componentDidUpdate(_: WrappedProps, prevState: WrappedState) {
-                if (this.state.locale !== prevState.locale) {
-                    this.props.destroyIntlProvider();
-                    this.props.createIntlProvider({
+                if (this.state.intl !== prevState.intl) {
+                    this.props.setIntl({
                         intl: this.state.intl,
                     });
                 }
-            }
-
-            componentWillUnmount() {
-                this.props.destroyIntlProvider();
             }
 
             render() {
@@ -90,8 +84,7 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
 
         const mapStateToProps = (state: State) => translateSelector(state);
         const mapDispatchToProps = {
-            createIntlProvider,
-            destroyIntlProvider,
+            setIntl,
         };
 
         return connect(mapStateToProps, mapDispatchToProps)(Translatable);

--- a/src/HOC/translatableFactory.tsx
+++ b/src/HOC/translatableFactory.tsx
@@ -34,9 +34,9 @@ const translatableFactory = (intlLocaleData: LocaleData): any => {
 
     return (TranslatableComponent: React.ComponentClass<WrappedProps>) => {
         class Translatable extends Component<WrappedProps, WrappedState> {
-            private cache: IntlCache = createIntlCache();
+            cache: IntlCache = createIntlCache();
 
-            public state: WrappedState = {
+            state: WrappedState = {
                 locale: this.props.locale,
                 intl: createIntl(prepareConfig(this.props), this.cache),
                 cache: this.cache,

--- a/src/services/actionTypes.ts
+++ b/src/services/actionTypes.ts
@@ -1,8 +1,7 @@
 enum actionTypes {
     SET_LOCALE = '@@jerome/SET_LOCALE',
     GET_LOCALE = '@@jerome/GET_LOCALE',
-    CREATE_INTL_PROVIDER = '@@jerome/CREATE_INTL_PROVIDER',
-    DESTROY_INTL_PROVIDER = '@@jerome/DESTROY_INTL_PROVIDER',
+    SET_INTL = '@@jerome/SET_INTL',
 }
 
 export default actionTypes;

--- a/src/services/actions.ts
+++ b/src/services/actions.ts
@@ -14,13 +14,9 @@ export function getLocale(): Action {
     };
 }
 
-export const createIntlProvider = (payload = {}): Action => ({
+export const setIntl = (payload = {}): Action => ({
     payload,
-    type: actionTypes.CREATE_INTL_PROVIDER,
-});
-
-export const destroyIntlProvider = (): Action => ({
-    type: actionTypes.DESTROY_INTL_PROVIDER,
+    type: actionTypes.SET_INTL,
 });
 
 export { actionTypes };

--- a/src/services/sagas/intlProvider.ts
+++ b/src/services/sagas/intlProvider.ts
@@ -1,61 +1,25 @@
-import { Action, Store } from '../../types';
-import { select, takeEvery, call, take, race } from 'redux-saga/effects';
-import { createIntl, createIntlCache } from 'react-intl';
+import { Action } from '../../types';
+import { call, take, race } from 'redux-saga/effects';
+import { IntlShape } from 'react-intl';
 
 import types from '../actionTypes';
-import { translateSelector } from '../selectors';
 
-const store: Store = {
-    locale: null,
-    intl: null,
-    intlData: {},
-};
+let intl: IntlShape | null = null;
 
-function* createIntlProvider() {
-    if (!store.intlData) {
-        yield take(types.CREATE_INTL_PROVIDER);
-    }
-
-    const { locale } = yield select(translateSelector);
-
-    if (store.locale === locale && store.intl) {
-        return;
-    }
-
-    store.locale = locale;
-
-    const intlConfig = {
-        locale,
-        key: locale,
-        messages: store.intlData[locale],
-    };
-
-    const cache = createIntlCache();
-    const intl = createIntl(intlConfig, cache);
-
-    store.intl = intl;
+function* initializedIntlProvider(action: Action) {
+    intl = action.payload.intl;
 }
 
 export function* getIntl() {
-    if (!store.intl) {
-        yield createIntlProvider();
+    if (!intl) {
+        const { payload } = yield take(types.CREATE_INTL_PROVIDER);
+        return payload.intl;
     }
-
-    return store.intl;
-}
-
-function* initializedIntlProvider(action: Action) {
-    store.intlData = action.payload.intlData;
-
-    yield call(createIntlProvider);
-
-    yield takeEvery(types.SET_LOCALE, createIntlProvider);
+    return intl;
 }
 
 function cleanUp() {
-    store.intl = null;
-    store.intlData = {};
-    store.locale = null;
+    intl = null;
 }
 
 export default function* intlProviderFlow() {

--- a/src/services/sagas/intlProvider.ts
+++ b/src/services/sagas/intlProvider.ts
@@ -1,40 +1,23 @@
 import { Action } from '../../types';
-import { call, take, race } from 'redux-saga/effects';
+import { take, takeEvery } from 'redux-saga/effects';
 import { IntlShape } from 'react-intl';
 
 import types from '../actionTypes';
 
 let intl: IntlShape | null = null;
 
-function* initializedIntlProvider(action: Action) {
+function setIntl(action: Action) {
     intl = action.payload.intl;
 }
 
 export function* getIntl() {
     if (!intl) {
-        const { payload } = yield take(types.CREATE_INTL_PROVIDER);
+        const { payload } = yield take(types.SET_INTL);
         return payload.intl;
     }
     return intl;
 }
 
-function cleanUp() {
-    intl = null;
-}
-
 export default function* intlProviderFlow() {
-    while (true) {
-        const action = yield take(types.CREATE_INTL_PROVIDER);
-
-        const result = yield race({
-            task: call(initializedIntlProvider, action),
-            cancel: take(types.DESTROY_INTL_PROVIDER),
-        });
-
-        if (!result.cancel) {
-            yield take(types.DESTROY_INTL_PROVIDER);
-        }
-
-        cleanUp();
-    }
+    yield takeEvery(types.SET_INTL, setIntl);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,21 +16,11 @@ export interface Action {
 }
 
 export interface LocaleData<T = {}> {
-    [locale: string]: object & T;
+    [locale: string]: T;
 }
 
 export interface Console {
     error(...args: any[]): any;
     warn(...args: any[]): any;
     log(...args: any[]): any;
-}
-
-export interface IntlLocaleData {
-    readonly [key: string]: any;
-}
-
-export interface Store {
-    locale: string | null;
-    intl: object | null;
-    intlData: IntlLocaleData;
 }


### PR DESCRIPTION
The new version of react-intl supports creating an intl instance outside of the `IntlProvider` and providing it straight to the reexported context provider `RawIntlProvider`. We can use this ability to simplify the `intlProvider` saga.

The intl instance is now created in the `withTranslatable` HOC and provided into the `RawIntlProvider` for the react usage and sent to the `intlProvider` saga for the saga usage.  

This solution simplifies the `intlProvider` saga since it doesn't have to create a duplication of an intl instance every time an app locale changes. 