### PR TITLE
🐛 Catch errors when opening DB and fallback to mock DB in that case

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     },
     "husky": {
         "hooks": {
-            "pre-push": "npm run test"
+            "pre-push": "npm run lint && npm run test"
         }
     }
 }

--- a/src/services/sagas/storageHandlers/IndexedDBWrapper.ts
+++ b/src/services/sagas/storageHandlers/IndexedDBWrapper.ts
@@ -1,17 +1,25 @@
 import { openDB as openDBReal } from 'idb';
+
 import openDBMock from './indexedDbMock';
 import { isBrowserEnv } from '../../../config';
+import { IDBLikeDatabase } from '../../../types';
 
 const DATABASE_NAME = '@ackee/jerome';
 const DATABASE_VERSION = 1;
 const DATABASE_STORE_NAME = 'keyvaluepairs';
 
-const openDB = isBrowserEnv && window.indexedDB ? openDBReal : openDBMock;
+const openDB = isBrowserEnv && window.indexedDB ? openDBReal : openDBMock;
 
-const db = openDB(DATABASE_NAME, DATABASE_VERSION, {
-    upgrade(nextDb: any) {
-        nextDb.createObjectStore(DATABASE_STORE_NAME);
-    },
+let db: Promise<IDBLikeDatabase>;
+
+db = Promise.resolve(
+    openDB(DATABASE_NAME, DATABASE_VERSION, {
+        upgrade(nextDb: any) {
+            nextDb.createObjectStore(DATABASE_STORE_NAME);
+        },
+    }),
+).catch(err => {
+    return openDBMock();
 });
 
 export async function get(key: string) {

--- a/src/services/sagas/storageHandlers/indexedDbMock.ts
+++ b/src/services/sagas/storageHandlers/indexedDbMock.ts
@@ -7,11 +7,11 @@ export class IndexedDbMock {
         this.db = {};
     }
 
-    get(storeName: string, key: string): any {
+    get(_: string, key: string): any {
         return this.db[key];
     }
 
-    put(storeName: string, val: any, key: string) {
+    put(_: string, val: any, key: string) {
         this.db[key] = val;
         return Promise.resolve(key);
     }

--- a/src/services/sagas/storageHandlers/indexedDbMock.ts
+++ b/src/services/sagas/storageHandlers/indexedDbMock.ts
@@ -1,19 +1,22 @@
+import { IDBLikeDatabase } from '../../../types';
+
 export class IndexedDbMock {
-    private db: {[key: string]: any};
+    private db: { [key: string]: any };
 
     constructor() {
         this.db = {};
     }
 
-    get(key: string): any {
+    get(storeName: string, key: string): any {
         return this.db[key];
     }
 
-    put(val: any, key: string) {
+    put(storeName: string, val: any, key: string) {
         this.db[key] = val;
+        return Promise.resolve(key);
     }
 }
 
-export default (): IndexedDbMock => {
-    return new IndexedDbMock();
+export default (): Promise<IDBLikeDatabase> => {
+    return Promise.resolve(new IndexedDbMock());
 };

--- a/src/services/sagas/storageHandlers/storageWrappers.story.tsx
+++ b/src/services/sagas/storageHandlers/storageWrappers.story.tsx
@@ -1,0 +1,40 @@
+import 'babel-polyfill';
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
+import 'antd/es/pagination/style/index.less';
+
+import * as database from './IndexedDBWrapper';
+
+storiesOf('services|Storage handlers', module).add('simple', () => {
+    const key = 'itemKey';
+    return (
+        <div>
+            <form
+                onSubmit={async e => {
+                    e.preventDefault();
+                    const formElement: HTMLFormElement = e.target;
+
+                    const input: HTMLInputElement = formElement.elements[0];
+                    await database.set(key, input.value);
+
+                    formElement.reset();
+                }}
+            >
+                <input name="user-text" type="text" />
+                <button type="submit">Save to the storage</button>
+            </form>
+
+            <button
+                type="button"
+                onClick={async () => {
+                    const value = await database.get(key);
+                    alert(value);
+                }}
+            >
+                What's in the storage?
+            </button>
+        </div>
+    );
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,3 @@
-import {
-    StoreNames, DBSchema } from 'idb';
-
 import actionTypes from './services/actionTypes';
 
 export type Locale = string;
@@ -28,9 +25,7 @@ export interface Console {
     log(...args: any[]): any;
 }
 
-export interface IDBLikeDatabase<DBTypes extends DBSchema | unknown = unknown, StoreName extends StoreNames<DBTypes> = StoreNames<DBTypes>> {
-    // get(query: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<StoreValue<DBTypes, StoreName> | undefined>;
-    // put(value: StoreValue<DBTypes, StoreName>, key?: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<StoreKey<DBTypes, StoreName>>;
+export interface IDBLikeDatabase {
     get(storeName: string, key: string): any;
     put(storeName: string, value: any, key: string): any;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+import {
+    StoreNames, DBSchema } from 'idb';
+
 import actionTypes from './services/actionTypes';
 
 export type Locale = string;
@@ -23,4 +26,11 @@ export interface Console {
     error(...args: any[]): any;
     warn(...args: any[]): any;
     log(...args: any[]): any;
+}
+
+export interface IDBLikeDatabase<DBTypes extends DBSchema | unknown = unknown, StoreName extends StoreNames<DBTypes> = StoreNames<DBTypes>> {
+    // get(query: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<StoreValue<DBTypes, StoreName> | undefined>;
+    // put(value: StoreValue<DBTypes, StoreName>, key?: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<StoreKey<DBTypes, StoreName>>;
+    get(storeName: string, key: string): any;
+    put(storeName: string, value: any, key: string): any;
 }


### PR DESCRIPTION
Add fallback to the mock DB when opening real database fail. Fixes using jerome in private browsing mode.

Resolves #21 